### PR TITLE
Add sequence_number to gateway firewall drop-all policy

### DIFF
--- a/stages/02a-nsxt/terraform.tfvars.example
+++ b/stages/02a-nsxt/terraform.tfvars.example
@@ -60,7 +60,8 @@ gwf_policies = [
     ]
   },
   {
-    display_name = "gwf_drop_policy"
+    display_name    = "gwf_drop_policy"
+    sequence_number = 1000
     rules = [
       {
         action             = "DROP"


### PR DESCRIPTION
This adds `sequence_number` to the gateway firewall drop-all policy so that it is aligned with the distributed firewall policy.