### PR TITLE
Fix GitHub runner ubuntu version

### DIFF
--- a/test/setup/github-runners/main.tf
+++ b/test/setup/github-runners/main.tf
@@ -15,23 +15,25 @@
  */
 
 module "gcve_github_actions_runners" {
-  source            = "github.com/terraform-google-modules/terraform-google-github-actions-runners//modules/gh-runner-mig-vm?ref=v3.1.0"
-  create_network    = var.create_network
-  create_subnetwork = var.create_subnetwork
-  project_id        = var.project_id
-  repo_name         = var.repo_name
-  repo_owner        = var.repo_owner
-  gh_token          = var.gh_token
-  instance_name     = var.instance_name
-  machine_type      = var.machine_type
-  region            = var.region
-  zone              = var.zone
-  max_replicas      = var.max_replicas
-  min_replicas      = var.min_replicas
-  network_name      = var.network_name
-  subnet_name       = var.subnet_name
-  startup_script    = file("${path.cwd}/scripts/startup.sh")
-  shutdown_script   = file("${path.cwd}/scripts/shutdown.sh")
+  source               = "github.com/terraform-google-modules/terraform-google-github-actions-runners//modules/gh-runner-mig-vm?ref=v3.1.0"
+  create_network       = var.create_network
+  create_subnetwork    = var.create_subnetwork
+  project_id           = var.project_id
+  repo_name            = var.repo_name
+  repo_owner           = var.repo_owner
+  gh_token             = var.gh_token
+  instance_name        = var.instance_name
+  machine_type         = var.machine_type
+  source_image_project = var.source_image_project
+  source_image_family  = var.source_image_family
+  region               = var.region
+  zone                 = var.zone
+  max_replicas         = var.max_replicas
+  min_replicas         = var.min_replicas
+  network_name         = var.network_name
+  subnet_name          = var.subnet_name
+  startup_script       = file("${path.cwd}/scripts/startup.sh")
+  shutdown_script      = file("${path.cwd}/scripts/shutdown.sh")
 }
 
 resource "null_resource" "wait_for_runner" {

--- a/test/setup/github-runners/terraform.tfvars
+++ b/test/setup/github-runners/terraform.tfvars
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-project_id        = ""
-repo_name         = "gcve-iac-foundations"
-repo_owner        = "GoogleCloudPlatform"
-gh_token          = ""
-create_network    = false
-create_subnetwork = false
-instance_name     = ""
-machine_type      = "t2d-standard-1"
-region            = "asia-southeast1"
-zone              = "asia-southeast1-b"
-max_replicas      = 1
-min_replicas      = 1
-network_name      = "gcve-vpc-net"
-subnet_name       = "gcve-asia-southeast1-connection-subnet"
+project_id           = ""
+repo_name            = "gcve-iac-foundations"
+repo_owner           = "GoogleCloudPlatform"
+gh_token             = ""
+create_network       = false
+create_subnetwork    = false
+instance_name        = ""
+machine_type         = "t2d-standard-1"
+region               = "asia-southeast1"
+zone                 = "asia-southeast1-b"
+max_replicas         = 1
+min_replicas         = 1
+network_name         = "gcve-vpc-net"
+subnet_name          = "gcve-asia-southeast1-connection-subnet"
+source_image_project = "ubuntu-os-cloud"
+source_image_family  = "ubuntu-2204-lts"


### PR DESCRIPTION
The default OS version of GCE OS (ubuntu-1804-lts) for the runner in the used module have been deprecated

Deprecation link : https://cloud.google.com/compute/docs/images/os-details#ubuntu_lts
Link to the module : https://github.com/terraform-google-modules/terraform-google-github-actions-runners/tree/master/modules/gh-runner-mig-vm

Fixes the OS version by specifying  it in the variables 


- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
