### PR TITLE
Add 02a-nsxt-tf-var stage and additional FW options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ This stage contains the Terraform content to deploy a private cloud and configur
 ### 02a-nsxt
 This stage contains the Terraform content for a foundational NSX-T setup (segments, firewalls). This stage can be deployed in parallel with stage `02b-vcenter`.
 
+### 02a-nsxt-tf-var
+This stage contains the Terraform content for a foundational NSX-T setup (segments, firewalls). This stage can be deployed in parallel with stage `02b-vcenter`. You can choose this stage to configure the NSX-T resources via Terraform variables.
+
 ### 02b-vcenter
 This stage contains the Terraform content for a foundational vCenter setup (folders, resource pools, roles). This stage can be deployed in parallel with stage `02a-nsxt`.
 

--- a/modules/nsxt-distributed-firewall-policy/main.tf
+++ b/modules/nsxt-distributed-firewall-policy/main.tf
@@ -105,7 +105,11 @@ resource "nsxt_policy_security_policy" "this" {
       direction             = upper(rule.value.direction)
       logged                = rule.value.logged
       services              = [for s in rule.value.services : data.nsxt_policy_service.this[s].path]
-
+      notes                 = rule.value.notes
+      profiles              = rule.value.profiles
+      scope                 = rule.value.scope
+      log_label             = rule.value.log_label
+      
       dynamic "tag" {
         for_each = coalesce(rule.value.tags, {})
         content {

--- a/modules/nsxt-distributed-firewall-policy/variables.tf
+++ b/modules/nsxt-distributed-firewall-policy/variables.tf
@@ -95,6 +95,10 @@ variable "rules" {
     source_groups         = optional(list(string))
     sources_excluded      = optional(bool)
     tags                  = optional(map(string))
+    notes                 = optional(string)
+    profiles              = optional(list(string))
+    scope                 = optional(list(string))
+    log_label             = optional(string)
   }))
   default = []
 }

--- a/stages/02a-nsxt-tf-var/README.md
+++ b/stages/02a-nsxt-tf-var/README.md
@@ -1,0 +1,29 @@
+# NSX-T Stage
+
+## Use Cases
+
+In this stage you configure NSX-T with segments and gateway firewall policies.
+
+Use the `terraform.tfvars.example` file as a template to populate the variables to deploy segements and firewalls.
+
+## Prerequisites
+
+ * Private Cloud is already deployed and accessible
+
+## Instructions
+
+To deploy this stage from a local UNIX shell, follow the steps:
+ * Rename (or copy) the file `terraform.tfvars.example` to `terraform.tfvars` and fill in suitable variables for your environment.
+ * Supply variables related to your GCVE NSX-T environment:
+   * `export TF_VAR_nsxt_url=nsx-123456.abcdef01.asia-southeast1.gve.goog`
+   * `export TF_VAR_nsxt_user=admin`
+   * `export TF_VAR_nsxt_password="......."` # keep the quotations around the password
+ * Initialize Terraform: `terraform init`
+ * Validate the resources created by Terraform: `terraform plan`
+ * Apply Terraform configurations: `terraform apply`
+
+## Dependencies
+
+ * modules/nsxt-segment
+ * modules/nsxt-gateway-firewall
+ * modules/nsxt-policy-group

--- a/stages/02a-nsxt-tf-var/main.tf
+++ b/stages/02a-nsxt-tf-var/main.tf
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+data "nsxt_policy_edge_cluster" "this" {
+  display_name = var.edge_cluster_name
+}
+
+data "nsxt_policy_tier0_gateway" "this" {
+  display_name = var.tier0_gateway_name
+}
+
+data "nsxt_policy_tier1_gateway" "this" {
+  display_name = var.tier1_gateway_name
+}
+
+data "nsxt_policy_transport_zone" "transport_zone" {
+  display_name = var.transport_zone_name
+}
+
+module "vm_segments" {
+  source   = "../../modules/nsxt-segment/"
+  for_each = { for k, v in var.segments : v.display_name => v }
+
+  connectivity_path    = data.nsxt_policy_tier1_gateway.this.path
+  display_name         = each.value.display_name
+  resource_description = each.value.description
+  segment_cidr         = each.value.cidr
+  tags                 = each.value.tags
+  transport_zone_path  = data.nsxt_policy_transport_zone.transport_zone.path
+}
+
+module "gwf_policies" {
+  source   = "../../modules/nsxt-gateway-firewall/"
+  for_each = { for k, v in var.gwf_policies : v.display_name => v }
+
+  display_name    = each.value.display_name
+  sequence_number = each.value.sequence_number
+
+  resource_description = try(each.value.resource_description, "Terraform provisioned")
+  stateful             = try(each.value.stateful, true)
+  tcp_strict           = try(each.value.tcp_strict, true)
+  locked               = try(each.value.locked, true)
+  tags                 = try(each.value.tags, {})
+  domain               = try(each.value.domain, null)
+  comments             = try(each.value.comments, null)
+
+  scope_path = data.nsxt_policy_tier1_gateway.this.path
+
+  custom_l4_services = try(each.value.custom_l4_services, {})
+
+  rules = each.value.rules
+
+  depends_on = [module.vm_segments]
+}
+
+module "dfw_policies" {
+  source   = "../../modules/nsxt-distributed-firewall-policy/"
+  for_each = { for k, v in var.dfw_policies : v.display_name => v }
+
+  display_name    = each.value.display_name
+  sequence_number = each.value.sequence_number
+
+  resource_description = try(each.value.resource_description, "Terraform provisioned")
+  category             = try(each.value.category, "Application")
+  stateful             = try(each.value.stateful, true)
+  tcp_strict           = try(each.value.tcp_strict, true)
+  locked               = try(each.value.locked, true)
+  tags                 = try(each.value.tags, {})
+  domain               = try(each.value.domain, null)
+  comments             = try(each.value.comments, null)
+
+  scope = try(each.value.scope, [])
+
+  custom_l4_services = try(each.value.custom_l4_services, {})
+
+  rules = each.value.rules
+
+  # depends_on = [
+  #   module.vm_segments,
+  #   module.policy_groups
+  # ]
+}
+
+module "policy_groups" {
+  for_each = { for k, v in var.policy_groups : v.display_name => v }
+
+  source = "../../modules/nsxt-policy-group/"
+
+  display_name = each.value.display_name
+  description  = try(each.value.description, "Managed by Terraform")
+
+  criteria = each.value.criteria
+
+  depends_on = [
+    module.vm_segments
+  ]
+}

--- a/stages/02a-nsxt-tf-var/outputs.tf
+++ b/stages/02a-nsxt-tf-var/outputs.tf
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "vm_segments" {
+  value = module.vm_segments
+}
+
+output "gwf_policies" {
+  value = module.gwf_policies
+}
+
+output "dfw_policies" {
+  value = module.dfw_policies
+}

--- a/stages/02a-nsxt-tf-var/terraform.tfvars.example
+++ b/stages/02a-nsxt-tf-var/terraform.tfvars.example
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// NSX-T Segments
+segments = [
+  {
+    description  = "example-subnet1"
+    display_name = "example-subnet1"
+    cidr         = "10.123.1.1/24"
+    tags = {
+      tier        = "web",
+      environment = "dev"
+    }
+  },
+  {
+    description  = "example-subnet2"
+    display_name = "example-subnet2"
+    cidr         = "10.123.1.1/24"
+    tags = {
+      tier        = "backend",
+      environment = "dev"
+    }
+  }
+]
+
+// NSX-T gateway firewall
+gwf_policies = [
+  {
+    display_name = "gwf_allow_policy"
+    rules = [
+      {
+        action             = "ALLOW"
+        destination_groups = ["10.123.1.0/24"]
+        source_groups      = ["10.100.0.0-10.100.0.128"]
+        direction          = "IN_OUT"
+        display_name       = "gwf-allow-ssh"
+        services           = ["SSH"]
+      },
+      {
+        action             = "ALLOW"
+        destination_groups = ["10.123.2.0/23"]
+        direction          = "IN_OUT"
+        display_name       = "gfw-allow-dns"
+        services           = ["DNS"]
+      },
+    ]
+  },
+  {
+    display_name    = "gwf_drop_policy"
+    sequence_number = 1000
+    rules = [
+      {
+        action             = "DROP"
+        destination_groups = ["10.123.2.0/23"]
+        direction          = "IN"
+        display_name       = "gfw-drop-all"
+      }
+    ]
+  },
+]
+
+// NSX-T distributed firewall
+dfw_policies = [
+  {
+    display_name    = "dfw_app_example_allow_policy"
+    sequence_number = 1
+    # scope           = ["/infra/domains/default/groups/GROUP-ID"]
+    rules = [
+      {
+        action             = "ALLOW"
+        direction          = "IN_OUT"
+        display_name       = "dfw-allow-ssh"
+        destination_groups = ["10.123.1.0/24"]
+        services           = ["SSH"]
+      },
+      {
+        action             = "ALLOW"
+        direction          = "IN_OUT"
+        display_name       = "dfw-allow-dns"
+        destination_groups = ["10.123.1.0/24"]
+        source_groups      = ["10.200.1.0-10.200.1.128"]
+        services           = ["DNS"]
+      },
+        {
+        action             = "ALLOW"
+        direction          = "IN_OUT"
+        display_name       = "dfw-allow-http"
+        destination_groups = ["group_app_example"]
+        source_groups      = ["10.200.1.0-10.200.1.128"]
+        services           = ["HTTP"]
+      },
+    ]
+  },
+  {
+    display_name    = "dfw_baseline_deny_policy"
+    sequence_number = 1000
+    rules = [
+      {
+        action       = "DROP"
+        direction    = "IN"
+        display_name = "dfw-drop-all"
+        logged       = true
+      }
+    ]
+  },
+]
+
+policy_groups = [
+  {
+    display_name = "group_app_example"
+    description  = "test group_app_example"
+    criteria = [
+      {
+        key         = "Tag"
+        member_type = "VirtualMachine"
+        operator    = "EQUALS"        
+        value       = "group_app_example"
+      },
+    ]
+  },
+]

--- a/stages/02a-nsxt-tf-var/variables.tf
+++ b/stages/02a-nsxt-tf-var/variables.tf
@@ -1,0 +1,165 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+variable "edge_cluster_name" {
+  description = "The name of the NSX-T Edge Cluster."
+  type        = string
+  default     = "edge-cluster" # < This is the GCVE default
+}
+
+variable "nsxt_url" {
+  type        = string
+  description = "The NSX-T endpoint URL."
+}
+
+variable "nsxt_user" {
+  type        = string
+  description = "The NSX-T administrative user to use for Terraform executions."
+}
+
+variable "nsxt_password" {
+  type        = string
+  description = "The password for the NSX-T administrative user."
+  sensitive   = true
+}
+
+variable "segments" {
+  description = "An list of segment configuration objects used to create segments."
+  type = list(object({
+    description  = string
+    display_name = string
+    cidr         = string
+    tags         = map(string)
+  }))
+}
+
+variable "transport_zone_name" {
+  description = "The name of the NSX-T Transport Zone."
+  type        = string
+  default     = "TZ-OVERLAY" # < This is the GCVE default
+}
+
+variable "tier0_gateway_name" {
+  description = "The name of the NSX-T tier0 gateway."
+  type        = string
+  default     = "Provider-LR" # < This is the GCVE default
+}
+
+variable "tier1_gateway_name" {
+  description = "The name of the NSX-T tier1 gateway."
+  type        = string
+  default     = "Tier1" # < This is the GCVE default
+}
+
+variable "gwf_policies" {
+  description = "A list of firewall configuration objects used to add firewall rules to the Tier1 Gateway."
+  type = list(object({
+    display_name         = string
+    sequence_number      = optional(number)
+    resource_description = optional(string, "Terraform provisioned")
+    stateful             = optional(bool, true)
+    tcp_strict           = optional(bool, true)
+    locked               = optional(bool, true)
+    tags                 = optional(map(string), {})
+    domain               = optional(string)
+    comments             = optional(string)
+
+    rules = list(object({
+      display_name          = string
+      action                = string
+      direction             = string
+      description           = optional(string)
+      disabled              = optional(bool, false)
+      logged                = optional(bool, false)
+      services              = optional(list(string), [])
+      destination_groups    = optional(list(string), [])
+      destinations_excluded = optional(bool, false)
+      source_groups         = optional(list(string), [])
+      sources_excluded      = optional(bool, false)
+      tags                  = optional(map(string), {})
+    }))
+
+    custom_l4_services = optional(map(object({
+      description       = string
+      protocol          = optional(string)
+      destination_ports = optional(list(number))
+      source_ports      = optional(list(number))
+      tags              = optional(map(string))
+    })), {})
+  }))
+  default = []
+}
+
+variable "dfw_policies" {
+  description = "A list of firewall configuration objects used to add firewall rules to the Tier1 Gateway."
+  type = list(object({
+    display_name         = string
+    sequence_number      = number
+    resource_description = optional(string, "Terraform provisioned")
+    category             = optional(string, "Application")
+    stateful             = optional(bool, true)
+    tcp_strict           = optional(bool, true)
+    locked               = optional(bool, true)
+    tags                 = optional(map(string), {})
+    domain               = optional(string)
+    comments             = optional(string)
+    scope                = optional(list(string), [])
+
+    rules = list(object({
+      display_name          = string
+      action                = string
+      direction             = string
+      description           = optional(string)
+      disabled              = optional(bool, false)
+      logged                = optional(bool, false)
+      services              = optional(list(string), [])
+      destination_groups    = optional(list(string), [])
+      destinations_excluded = optional(bool, false)
+      source_groups         = optional(list(string), [])
+      sources_excluded      = optional(bool, false)
+      tags                  = optional(map(string), {})
+      notes                 = optional(string)
+      profiles              = optional(list(string), [])
+      scope                 = optional(list(string), [])
+      log_label             = optional(string)
+    }))
+
+    custom_l4_services = optional(map(object({
+      description       = string
+      protocol          = optional(string)
+      destination_ports = optional(list(number))
+      source_ports      = optional(list(number))
+      tags              = optional(map(string))
+    })), {})
+  }))
+  default = []
+}
+
+variable "policy_groups" {
+  description = "A list of firewall configuration objects used to add firewall rules to the Tier1 Gateway."
+  type = list(object({
+    display_name = string
+    description  = string
+    criteria = list(object({
+      key         = string
+      member_type = string
+      operator    = string
+      value       = string
+    }))
+  }))
+  default = []
+}

--- a/stages/02a-nsxt-tf-var/versions.tf
+++ b/stages/02a-nsxt-tf-var/versions.tf
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# In the future this could be generated from the output of stage 01-privatecloud.
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    nsxt = {
+      source  = "vmware/nsxt"
+      version = ">= 3.3.1"
+    }
+  }
+}
+
+provider "nsxt" {
+  host                 = var.nsxt_url
+  username             = var.nsxt_user
+  password             = var.nsxt_password
+  allow_unverified_ssl = true
+}


### PR DESCRIPTION
Add a new 02a-nsxt-tf-var stage, this can be implemented instead of the original 02a-nsxt.

02a-nsxt-tf-var is similar to 02a-nsxt but uses extended options for all the resources in the stage. This is in preparation for other stages that should expose all options available in the NSX-T resources.

To implement per app resources, for example groups or distributed firewall policies, there is a single Terraform variable, that accepts a list of resource configurations.

Additionally, add more options available to the
nsxt-distributed-firewall-policy module, so we can expose them in the 02a-nsxt-tf-var module.

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
