### PR TITLE
Bug With vsphere_network

### DIFF
--- a/examples/gcve-network-peering/main.tf
+++ b/examples/gcve-network-peering/main.tf
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+data "google_vmwareengine_network" "network-peering-nw" {
+  name     = var.nw_name
+  location = var.nw_location
+  project  = var.nw_project_id
+}
+
 module "gcve_network_peering" {
   source     = "../../modules/gcve-network-peering"
   project_id = var.project_id
@@ -23,9 +29,7 @@ module "gcve_network_peering" {
   peer_network_type     = var.peer_network_type
 
   # vmware network
-  nw_name       = var.nw_name
-  nw_location   = var.nw_location
-  nw_project_id = var.nw_project_id
+  vmware_engine_network_id = data.google_vmwareengine_network.network-peering-nw.id
 
   # peer network configs
   peer_nw_name       = var.peer_nw_name

--- a/examples/gcve-private-cloud/main.tf
+++ b/examples/gcve-private-cloud/main.tf
@@ -17,11 +17,11 @@
 module "gcve-private-cloud" {
   source                            = "../../modules/gcve-private-cloud"
   project                           = var.project
-  gcve_region                       = var.gcve_region
   gcve_zone                         = var.gcve_zone
   vmware_engine_network_name        = var.vmware_engine_network_name
   vmware_engine_network_type        = var.vmware_engine_network_type
   vmware_engine_network_description = var.vmware_engine_network_description
+  vmware_engine_network_location    = var.vmware_engine_network_location
   create_vmware_engine_network      = var.create_vmware_engine_network
   pc_name                           = var.pc_name
   pc_cidr_range                     = var.pc_cidr_range

--- a/examples/gcve-private-cloud/variables.tf
+++ b/examples/gcve-private-cloud/variables.tf
@@ -18,10 +18,6 @@ variable "project" {
   type        = string
   description = "Project where private cloud will be deployed"
 }
-variable "gcve_region" {
-  type        = string
-  description = "Region where private cloud will be deployed"
-}
 variable "gcve_zone" {
   type        = string
   description = "Zone where private cloud will be deployed"
@@ -41,6 +37,11 @@ variable "vmware_engine_network_description" {
   type        = string
   description = "Description of the vmware engine network for the private cloud"
   default     = "PC Network"
+}
+
+variable "vmware_engine_network_location" {
+  type        = string
+  description = "Location where vmware engine network will be deployed"
 }
 
 variable "create_vmware_engine_network" {

--- a/modules/gcve-monitoring/main.tf
+++ b/modules/gcve-monitoring/main.tf
@@ -75,8 +75,10 @@ resource "google_compute_region_instance_group_manager" "mig_monitoring_gcve" {
     type                         = "PROACTIVE"
     instance_redistribution_type = "NONE"
   }
-  provisioner "local-exec" {
-    command = "gcloud --project ${var.project} beta compute instance-groups managed update ${google_compute_region_instance_group_manager.mig_monitoring_gcve.name} --stateful-internal-ip enabled --region ${var.gcve_region}"
+
+  stateful_internal_ip {
+    delete_rule    = "NEVER" 
+    interface_name = "nic0"
   }
 }
 

--- a/modules/gcve-network-peering/main.tf
+++ b/modules/gcve-network-peering/main.tf
@@ -15,12 +15,6 @@
  */
 
 
-data "google_vmwareengine_network" "network-peering-nw" {
-  name     = var.nw_name
-  location = var.nw_location
-  project  = var.nw_project_id
-}
-
 data "google_compute_network" "network-peering-peer-nw" {
   count   = var.peer_network_type == "STANDARD" ? 1 : 0
   name    = var.peer_nw_name
@@ -54,7 +48,7 @@ locals {
 
     var.peer_network_type == "DELL_POWERSCALE" ?
     "projects/${var.peer_nw_project_id}/global/networks/dellemc-tenant-vpc" :
-    
+
     "Error: wrong peer network type"
   )
 }
@@ -63,7 +57,7 @@ resource "google_vmwareengine_network_peering" "peering" {
   name                                = var.gcve_peer_name
   description                         = var.gcve_peer_description
   project                             = var.project_id
-  vmware_engine_network               = data.google_vmwareengine_network.network-peering-nw.id
+  vmware_engine_network               = var.vmware_engine_network_id
   peer_network                        = local.peer_network
   peer_network_type                   = var.peer_network_type
   export_custom_routes                = var.peer_export_custom_routes

--- a/modules/gcve-network-peering/variables.tf
+++ b/modules/gcve-network-peering/variables.tf
@@ -29,19 +29,9 @@ variable "peer_network_type" {
   }
 }
 
-variable "nw_name" {
+variable "vmware_engine_network_id" {
   type        = string
   description = "The relative resource name of the VMware Engine network"
-}
-
-variable "nw_location" {
-  type        = string
-  description = "The relative resource location of the VMware Engine network"
-}
-
-variable "nw_project_id" {
-  type    = string
-  default = "The relative resource project of the VMware Engine network"
 }
 
 variable "peer_nw_name" {

--- a/modules/gcve-private-cloud/README.md
+++ b/modules/gcve-private-cloud/README.md
@@ -20,11 +20,11 @@ module "example" {
 	 # Required variables
 	 cluster_id  = 
 	 create_vmware_engine_network  = 
-	 gcve_region  = 
 	 gcve_zone  = 
 	 pc_cidr_range  = 
 	 pc_name  = 
 	 project  = 
+	 vmware_engine_network_location  = 
 	 vmware_engine_network_name  = 
 
 	 # Optional variables
@@ -52,13 +52,13 @@ module "example" {
 | <a name="input_cluster_node_count"></a> [cluster\_node\_count](#input\_cluster\_node\_count) | Specify the number of nodes for the management cluster in the private cloud | `number` | `3` | no |
 | <a name="input_cluster_node_type"></a> [cluster\_node\_type](#input\_cluster\_node\_type) | Specify the node type for the management cluster in the private cloud | `string` | `"standard-72"` | no |
 | <a name="input_create_vmware_engine_network"></a> [create\_vmware\_engine\_network](#input\_create\_vmware\_engine\_network) | Set this value to true if you want to create a vmware engine network, | `bool` | n/a | yes |
-| <a name="input_gcve_region"></a> [gcve\_region](#input\_gcve\_region) | Region where private cloud will be deployed | `string` | n/a | yes |
 | <a name="input_gcve_zone"></a> [gcve\_zone](#input\_gcve\_zone) | Zone where private cloud will be deployed | `string` | n/a | yes |
 | <a name="input_pc_cidr_range"></a> [pc\_cidr\_range](#input\_pc\_cidr\_range) | CIDR range for the management network of the private cloud that will be deployed | `string` | n/a | yes |
 | <a name="input_pc_description"></a> [pc\_description](#input\_pc\_description) | Description for the private cloud that will be deployed | `string` | `"Private Cloud description"` | no |
 | <a name="input_pc_name"></a> [pc\_name](#input\_pc\_name) | Name of the private cloud that will be deployed | `string` | n/a | yes |
 | <a name="input_project"></a> [project](#input\_project) | Project where private cloud will be deployed | `string` | n/a | yes |
 | <a name="input_vmware_engine_network_description"></a> [vmware\_engine\_network\_description](#input\_vmware\_engine\_network\_description) | Description of the vmware engine network for the private cloud | `string` | `"PC Network"` | no |
+| <a name="input_vmware_engine_network_location"></a> [vmware\_engine\_network\_location](#input\_vmware\_engine\_network\_location) | Region where vmware engine network will be deployed | `string` | n/a | yes |
 | <a name="input_vmware_engine_network_name"></a> [vmware\_engine\_network\_name](#input\_vmware\_engine\_network\_name) | Name of the vmware engine network for the private cloud | `string` | n/a | yes |
 | <a name="input_vmware_engine_network_type"></a> [vmware\_engine\_network\_type](#input\_vmware\_engine\_network\_type) | Type of the vmware engine network for the private cloud | `string` | `"LEGACY"` | no |
 

--- a/modules/gcve-private-cloud/main.tf
+++ b/modules/gcve-private-cloud/main.tf
@@ -15,10 +15,11 @@
  */
 
 data "google_vmwareengine_network" "existing_vmware_engine_network" {
+  count    = var.create_vmware_engine_network ? 0 : 1
   provider = google-beta
   project  = var.project
   name     = var.vmware_engine_network_name
-  location = var.gcve_region
+  location = var.vmware_engine_network_location
 }
 
 resource "google_vmwareengine_network" "vmware_engine_network" {
@@ -26,7 +27,7 @@ resource "google_vmwareengine_network" "vmware_engine_network" {
   provider    = google-beta
   project     = var.project
   name        = var.vmware_engine_network_name
-  location    = var.gcve_region
+  location    = var.vmware_engine_network_location
   type        = var.vmware_engine_network_type
   description = var.vmware_engine_network_description
 }
@@ -39,7 +40,7 @@ resource "google_vmwareengine_private_cloud" "gcve_tf_pc" {
   description = var.pc_description
   network_config {
     management_cidr       = var.pc_cidr_range
-    vmware_engine_network = var.create_vmware_engine_network ? google_vmwareengine_network.vmware_engine_network[0].id : data.google_vmwareengine_network.existing_vmware_engine_network.id
+    vmware_engine_network = var.create_vmware_engine_network ? google_vmwareengine_network.vmware_engine_network[0].id : data.google_vmwareengine_network.existing_vmware_engine_network[0].id
   }
 
   management_cluster {

--- a/modules/gcve-private-cloud/outputs.tf
+++ b/modules/gcve-private-cloud/outputs.tf
@@ -53,3 +53,8 @@ output "state" {
   description = "Details about the state of the private cloud"
   value       = google_vmwareengine_private_cloud.gcve_tf_pc.state
 }
+
+output "network" {
+  description = "Details about the vmware engine network"
+  value       = var.create_vmware_engine_network ? google_vmwareengine_network.vmware_engine_network[0].id : data.google_vmwareengine_network.existing_vmware_engine_network[0].id
+}

--- a/modules/gcve-private-cloud/variables.tf
+++ b/modules/gcve-private-cloud/variables.tf
@@ -18,10 +18,7 @@ variable "project" {
   type        = string
   description = "Project where private cloud will be deployed"
 }
-variable "gcve_region" {
-  type        = string
-  description = "Region where private cloud will be deployed"
-}
+
 variable "gcve_zone" {
   type        = string
   description = "Zone where private cloud will be deployed"
@@ -41,6 +38,11 @@ variable "vmware_engine_network_description" {
   type        = string
   description = "Description of the vmware engine network for the private cloud"
   default     = "PC Network"
+}
+
+variable "vmware_engine_network_location" {
+  type        = string
+  description = "Location where vmware engine network will be deployed"
 }
 
 variable "create_vmware_engine_network" {

--- a/stages/01-privatecloud/01a-privatecloud/main.tf
+++ b/stages/01-privatecloud/01a-privatecloud/main.tf
@@ -17,11 +17,11 @@
 module "gcve-private-cloud" {
   source                            = "../../../modules/gcve-private-cloud"
   project                           = var.project
-  gcve_region                       = var.gcve_region
   gcve_zone                         = var.gcve_zone
   vmware_engine_network_name        = var.vmware_engine_network_name
   vmware_engine_network_type        = var.vmware_engine_network_type
   vmware_engine_network_description = var.vmware_engine_network_description
+  vmware_engine_network_location    = var.vmware_engine_network_location
   create_vmware_engine_network      = var.create_vmware_engine_network
   pc_name                           = var.pc_name
   pc_cidr_range                     = var.pc_cidr_range

--- a/stages/01-privatecloud/01a-privatecloud/terraform.tfvars.example
+++ b/stages/01-privatecloud/01a-privatecloud/terraform.tfvars.example
@@ -1,8 +1,9 @@
 project                           = "my-example-project"
-gcve_region                       = "asia-southeast1"
 gcve_zone                         = "asia-southeast1-a"
 vmware_engine_network_name        = "asia-southeast1-default"
 vmware_engine_network_description = "my-network-description"
+vmware_engine_network_location    = "global"
+vmware_engine_network_type        = "STANDARD"
 create_vmware_engine_network      = true
 pc_name                           = "my-private-cloud"
 pc_cidr_range                     = "10.0.0.0/22"

--- a/stages/01-privatecloud/01a-privatecloud/variables.tf
+++ b/stages/01-privatecloud/01a-privatecloud/variables.tf
@@ -18,10 +18,6 @@ variable "project" {
   type        = string
   description = "Project where private cloud will be deployed"
 }
-variable "gcve_region" {
-  type        = string
-  description = "Region where private cloud will be deployed"
-}
 variable "gcve_zone" {
   type        = string
   description = "Zone where private cloud will be deployed"
@@ -35,6 +31,11 @@ variable "vmware_engine_network_type" {
   type        = string
   description = "Type of the vmware engine network for the private cloud"
   default     = "LEGACY"
+}
+variable "vmware_engine_network_location" {
+  type        = string
+  description = "Location of the vmware engine network for the private cloud"
+  default     = "us-central1"
 }
 
 variable "vmware_engine_network_description" {

--- a/stages/01-privatecloud/01b-network-peering/variables.tf
+++ b/stages/01-privatecloud/01b-network-peering/variables.tf
@@ -97,7 +97,7 @@ variable "peer_import_custom_routes_with_public_ip" {
 
 ## dns peering variables
 variable "dns_peering" {
-  type = bool  
+  type = bool
 }
 
 variable "dns_name" {


### PR DESCRIPTION
Bug Fix
- Removed data block for private_cloud, as not necessary network will always exists.. plan fails if both are created in single go.
- Added new parameter to support vmware network location. as it can have global as value.
- gcve_region, is not supported actually, gcve private cloud cluster can be zonal only.

