### PR TITLE
fix: add pc_type variable for gcve-private-cloud module

### DIFF
--- a/modules/gcve-private-cloud/README.md
+++ b/modules/gcve-private-cloud/README.md
@@ -56,7 +56,7 @@ module "example" {
 | <a name="input_pc_cidr_range"></a> [pc\_cidr\_range](#input\_pc\_cidr\_range) | CIDR range for the management network of the private cloud that will be deployed | `string` | n/a | yes |
 | <a name="input_pc_description"></a> [pc\_description](#input\_pc\_description) | Description for the private cloud that will be deployed | `string` | `"Private Cloud description"` | no |
 | <a name="input_pc_name"></a> [pc\_name](#input\_pc\_name) | Name of the private cloud that will be deployed | `string` | n/a | yes |
-| <a name="input_pc_type"></a> [pc\ type](#input\_pc\_type) | Initial type of the private cloud. Possible values are: STANDARD, TIME_LIMITED | `string` | `"STANDARD"`  | no |
+| <a name="input_pc_type"></a> [pc\_type](#input\_pc\_type) | Initial type of the private cloud. Possible values are: STANDARD, TIME_LIMITED | `string` | `"STANDARD"`  | no |
 | <a name="input_project"></a> [project](#input\_project) | Project where private cloud will be deployed | `string` | n/a | yes |
 | <a name="input_vmware_engine_network_description"></a> [vmware\_engine\_network\_description](#input\_vmware\_engine\_network\_description) | Description of the vmware engine network for the private cloud | `string` | `"PC Network"` | no |
 | <a name="input_vmware_engine_network_location"></a> [vmware\_engine\_network\_location](#input\_vmware\_engine\_network\_location) | Region where vmware engine network will be deployed | `string` | n/a | yes |

--- a/modules/gcve-private-cloud/README.md
+++ b/modules/gcve-private-cloud/README.md
@@ -56,6 +56,7 @@ module "example" {
 | <a name="input_pc_cidr_range"></a> [pc\_cidr\_range](#input\_pc\_cidr\_range) | CIDR range for the management network of the private cloud that will be deployed | `string` | n/a | yes |
 | <a name="input_pc_description"></a> [pc\_description](#input\_pc\_description) | Description for the private cloud that will be deployed | `string` | `"Private Cloud description"` | no |
 | <a name="input_pc_name"></a> [pc\_name](#input\_pc\_name) | Name of the private cloud that will be deployed | `string` | n/a | yes |
+| <a name="input_pc_type"></a> [pc\ type](#input\_pc\_type) | Initial type of the private cloud. Possible values are: STANDARD, TIME_LIMITED | `string` | `"STANDARD"`  | no |
 | <a name="input_project"></a> [project](#input\_project) | Project where private cloud will be deployed | `string` | n/a | yes |
 | <a name="input_vmware_engine_network_description"></a> [vmware\_engine\_network\_description](#input\_vmware\_engine\_network\_description) | Description of the vmware engine network for the private cloud | `string` | `"PC Network"` | no |
 | <a name="input_vmware_engine_network_location"></a> [vmware\_engine\_network\_location](#input\_vmware\_engine\_network\_location) | Region where vmware engine network will be deployed | `string` | n/a | yes |

--- a/modules/gcve-private-cloud/main.tf
+++ b/modules/gcve-private-cloud/main.tf
@@ -38,6 +38,7 @@ resource "google_vmwareengine_private_cloud" "gcve_tf_pc" {
   location    = var.gcve_zone
   name        = var.pc_name
   description = var.pc_description
+  type        = var.pc_type
   network_config {
     management_cidr       = var.pc_cidr_range
     vmware_engine_network = var.create_vmware_engine_network ? google_vmwareengine_network.vmware_engine_network[0].id : data.google_vmwareengine_network.existing_vmware_engine_network[0].id

--- a/modules/gcve-private-cloud/variables.tf
+++ b/modules/gcve-private-cloud/variables.tf
@@ -67,6 +67,12 @@ variable "pc_description" {
   default     = "Private Cloud description"
 }
 
+variable "pc_type" {
+  type        = string
+  description = "Initial type of the private cloud. Possible values are: STANDARD, TIME_LIMITED"
+  default     = "STANDARD"  
+}
+
 variable "cluster_id" {
   type        = string
   description = "The cluster ID for management cluster in the private cloud"


### PR DESCRIPTION
Adds variable for setting the `google_vmwareengine_private_cloud` resource `type` attribute
Enables using `TIME_LIMITED` private clusters for trial environments