### PR TITLE
Adding storage only node support

### DIFF
--- a/modules/gcve-cluster/README.md
+++ b/modules/gcve-cluster/README.md
@@ -27,6 +27,8 @@ module "example" {
 	 cluster_node_count  = 3
 	 cluster_node_type  = "standard-72"
 	 custom_core_count  = 0
+         cluster_storage_node_count = 0
+	 cluster_storage_node_type = "storage-only-standard-72"
 }
 ```
 
@@ -45,6 +47,8 @@ module "example" {
 | <a name="input_cluster_node_count"></a> [cluster\_node\_count](#input\_cluster\_node\_count) | Specify the number of nodes for the management cluster in the private cloud | `number` | `3` | no |
 | <a name="input_cluster_node_type"></a> [cluster\_node\_type](#input\_cluster\_node\_type) | Specify the node type for the management cluster in the private cloud | `string` | `"standard-72"` | no |
 | <a name="input_custom_core_count"></a> [custom\_core\_count](#input\_custom\_core\_count) | Specify the number of cores available to each node of the cluster. The value 0 will use the largest amount of available cores on each node in the cluster. | `number` | `0` | no |
+| <a name="input_cluster_storage_node_count"></a> [cluster\_storage\_node\_count](#input\_cluster\_storage\_node\_count) | Specify the number of nodes for the management cluster in the private cloud | `number` | `0` | no |
+| <a name="input_cluster_storage_node_type"></a> [cluster\_storage\_node\_type](#input\_cluster\_storage\_node\_type) | Specify the node type for the management cluster in the private cloud | `string` | `"storage-only-standard-72"` | no |
 | <a name="input_gcve_zone"></a> [gcve\_zone](#input\_gcve\_zone) | Zone of the private cloud | `string` | n/a | yes |
 | <a name="input_pc_name"></a> [pc\_name](#input\_pc\_name) | Name of the private cloud that will be deployed | `string` | n/a | yes |
 | <a name="input_project"></a> [project](#input\_project) | Project where private cloud will be deployed | `string` | n/a | yes |

--- a/modules/gcve-cluster/main.tf
+++ b/modules/gcve-cluster/main.tf
@@ -30,4 +30,11 @@ resource "google_vmwareengine_cluster" "esxi-cluster" {
     node_count        = var.cluster_node_count
     custom_core_count = var.custom_core_count
   }
+  dynamic "node_type_configs" {
+    for_each = var.cluster_storage_node_count > 0 ? [1] : []
+    content {
+      node_type_id = var.cluster_storage_node_type
+      node_count   = var.cluster_storage_node_count
+    }
+  }
 }

--- a/modules/gcve-cluster/variables.tf
+++ b/modules/gcve-cluster/variables.tf
@@ -51,3 +51,15 @@ variable "custom_core_count" {
   description = "Specify the number of cores available to each node of the cluster. The value 0 will use the largest amount of available cores on each node in the cluster."
   default     = 0
 }
+
+variable "cluster_storage_node_type" {
+  type        = string
+  description = "Specify the node type for the management cluster in the private cloud"
+  default     = "storage-only-standard-72"
+}
+
+variable "cluster_storage_node_count" {
+  type        = number
+  description = "Specify the number of nodes for the management cluster in the private cloud"
+  default     = 0
+}

--- a/modules/gcve-private-cloud/README.md
+++ b/modules/gcve-private-cloud/README.md
@@ -30,6 +30,8 @@ module "example" {
 	 # Optional variables
 	 cluster_node_count  = 3
 	 cluster_node_type  = "standard-72"
+  	 cluster_storage_node_count = 0
+	 cluster_storage_node_type = "storage-only-standard-72"
 	 pc_description  = "Private Cloud description"
 	 vmware_engine_network_description  = "PC Network"
 	 vmware_engine_network_type  = "LEGACY"
@@ -51,6 +53,8 @@ module "example" {
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | The cluster ID for management cluster in the private cloud | `string` | n/a | yes |
 | <a name="input_cluster_node_count"></a> [cluster\_node\_count](#input\_cluster\_node\_count) | Specify the number of nodes for the management cluster in the private cloud | `number` | `3` | no |
 | <a name="input_cluster_node_type"></a> [cluster\_node\_type](#input\_cluster\_node\_type) | Specify the node type for the management cluster in the private cloud | `string` | `"standard-72"` | no |
+| <a name="input_cluster_storage_node_count"></a> [cluster\_storage\_node\_count](#input\_cluster\_storage\_node\_count) | Specify the number of storage only nodes for the management cluster in the private cloud | `number` | `0` | no |
+| <a name="input_cluster_storage_node_type"></a> [cluster\_storage\_node\_type](#input\_cluster\_storage\_node\_type) | Specify the storage only node type for the management cluster in the private cloud | `string` | `"storage-only-standard-72"` | no |
 | <a name="input_create_vmware_engine_network"></a> [create\_vmware\_engine\_network](#input\_create\_vmware\_engine\_network) | Set this value to true if you want to create a vmware engine network, | `bool` | n/a | yes |
 | <a name="input_gcve_zone"></a> [gcve\_zone](#input\_gcve\_zone) | Zone where private cloud will be deployed | `string` | n/a | yes |
 | <a name="input_pc_cidr_range"></a> [pc\_cidr\_range](#input\_pc\_cidr\_range) | CIDR range for the management network of the private cloud that will be deployed | `string` | n/a | yes |

--- a/modules/gcve-private-cloud/main.tf
+++ b/modules/gcve-private-cloud/main.tf
@@ -50,5 +50,12 @@ resource "google_vmwareengine_private_cloud" "gcve_tf_pc" {
       node_type_id = var.cluster_node_type
       node_count   = var.cluster_node_count
     }
+    dynamic "node_type_configs" {
+      for_each = var.cluster_storage_node_count > 0 ? [1] : []
+      content {
+        node_type_id = var.cluster_storage_node_type
+        node_count   = var.cluster_storage_node_count
+      }
+    }
   }
 }

--- a/modules/gcve-private-cloud/variables.tf
+++ b/modules/gcve-private-cloud/variables.tf
@@ -89,3 +89,15 @@ variable "cluster_node_count" {
   description = "Specify the number of nodes for the management cluster in the private cloud"
   default     = 3
 }
+
+variable "cluster_storage_node_type" {
+  type        = string
+  description = "Specify the node type for the management cluster in the private cloud"
+  default     = "storage-only-standard-72"
+}
+
+variable "cluster_storage_node_count" {
+  type        = number
+  description = "Specify the number of nodes for the management cluster in the private cloud"
+  default     = 0
+}


### PR DESCRIPTION
Fixes Adding support for storage nodes https://github.com/GoogleCloudPlatform/gcve-iac-foundations/issues/91

- Tested for private cloud module, used same code for the cluster module
